### PR TITLE
v0.11.0

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,8 +10,8 @@ jobs:
                 - 18.x
                 - 20.x
         steps:
-        - uses: actions/checkout@v3
-        - uses: actions/setup-node@v3
+        - uses: actions/checkout@v4
+        - uses: actions/setup-node@v4
           with:
               node-version: ${{ matrix.node-version }}
         - run: npm install-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ unreleased
 
 significant changes for end users:
 
+* allow to set additional meta tags via the `meta` configuration:
+    * expects an object, with the keys being the `name` and the values being the `content`
 * we no longer bundle the --serve and --live-serve dependencies - you will be asked to install them
 * reduce faucet dependencies
 * update all dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 aiur version history
 ====================
 
+unreleased
+----------
+
+significant changes for end users:
+
+* we no longer bundle the --serve and --live-serve dependencies - you will be asked to install them
+* reduce faucet dependencies
+* update all dependencies
+
 v0.10.0
 -------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 aiur version history
 ====================
 
-unreleased
-----------
+v0.11.0
+-------
 
 significant changes for end users:
 

--- a/bin/aiur
+++ b/bin/aiur
@@ -3,15 +3,7 @@
 
 let faucet = require("faucet-pipeline-core");
 let parseCLI = require("../lib/cli");
-let server = require("../lib/server");
 
 let { referenceDir, config, options } = parseCLI();
-let liveserve = options.liveserve;
 
-// We want to use our own live-server implementation instead of faucet
-delete options.liveserve;
 faucet(referenceDir, config, options);
-
-if(liveserve) {
-	server.live(liveserve, config.manifest.webRoot);
-}

--- a/example/aiur.config.js
+++ b/example/aiur.config.js
@@ -2,6 +2,9 @@
 
 exports.title = "Example Styleguide";
 exports.language = "en";
+exports.meta = {
+	robots: "noindex"
+};
 
 exports.vendor = {
 	styles: [{

--- a/lib/generate_layout.js
+++ b/lib/generate_layout.js
@@ -9,6 +9,7 @@ module.exports = async (navigation, manifest) => {
 		<title>${page.title || ""}</title>
 		<meta name="description" content="${page.description || ""}">
 		<meta name="viewport" content="width=device-width,initial-scale=1">
+		${page.meta}
 		<link href="${manifest.get("style-aiur.css")}" rel="stylesheet">
 	</head>
 	<body id="aiur">

--- a/lib/page.js
+++ b/lib/page.js
@@ -2,11 +2,11 @@ let { repr } = require("faucet-pipeline-core/lib/util");
 let colonParse = require("metacolon");
 
 module.exports = class Page {
-	constructor(slug, sourcePath, children, { language, title, description }, dataPath) {
+	constructor(slug, sourcePath, children, { language, title, description, meta }, dataPath) {
 		this.slug = slug || "";
 		this.sourcePath = sourcePath;
 		this.children = children || null;
-		this.config = { language, title, description };
+		this.config = { language, title, description, meta };
 		this.dataPath = dataPath;
 	}
 
@@ -27,11 +27,16 @@ module.exports = class Page {
 		this.heading = headers.title;
 		this.title = [headers.title, this.config.title].filter(x => x).join(" | ");
 		this.description = headers.description || this.config.description;
+		this.meta = this.buildMeta();
 		this.status = headers.status;
 		this.version = headers.version;
 		this.tags = headers.tags;
 		this.body = body;
 		return this;
+	}
+
+	buildMeta() {
+		return Object.entries(this.config.meta || {}).map(x => `<meta name="${x[0]}" content="${x[1]}">`).join("\n");
 	}
 
 	toString() {

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,8 +1,0 @@
-let { _parseHost } = require("faucet-pipeline-core/lib/server");
-
-exports.live = (config, root) => {
-	let LiveServer = require("five-server").default;
-	let [host, port] = _parseHost(config);
-
-	new LiveServer().start({ port, host, root, open: false });
-};

--- a/lib/style.scss
+++ b/lib/style.scss
@@ -294,8 +294,3 @@ resize-handle {
 		display: block;
 	}
 }
-
-/* disable five-server toast messages on page reload */
-#fiveserver-info-wrapper {
-	visibility: hidden;
-}

--- a/package.json
+++ b/package.json
@@ -25,14 +25,11 @@
 		"node": ">= 18"
 	},
 	"dependencies": {
-		"commonmark": "^0.30.0",
-		"donny": "^0.3.0",
+		"commonmark": "^0.31.2",
 		"faucet-pipeline-core": "^2.0.0",
-		"faucet-pipeline-esnext": "^3.0.0",
-		"faucet-pipeline-jsx": "^3.0.0",
+		"faucet-pipeline-js": "^3.0.0",
 		"faucet-pipeline-sass": "^1.7.0",
 		"faucet-pipeline-static": "^2.0.0",
-		"five-server": "^0.3.1",
 		"handlebars": "^4.7.7",
 		"metacolon": "^1.1.1",
 		"minimist": "^1.2.5",
@@ -44,6 +41,6 @@
 		"eslint-config-fnd": "^1.12.0",
 		"mocha": "^10.2.0",
 		"release-util-fnd": "^3.0.0",
-		"rimraf": "^5.0.1"
+		"rimraf": "^6.0.1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "aiur",
-	"version": "0.10.0",
+	"version": "0.11.0",
 	"description": "styleguide generator",
 	"main": "lib/index.js",
 	"bin": {

--- a/test/expectations/atoms/button/index.html
+++ b/test/expectations/atoms/button/index.html
@@ -5,6 +5,7 @@
 		<title>Button</title>
 		<meta name="description" content="interactive widget">
 		<meta name="viewport" content="width=device-width,initial-scale=1">
+		<meta name="robots" content="noindex">
 		<link href="/style-aiur.css" rel="stylesheet">
 	</head>
 	<body id="aiur">

--- a/test/expectations/atoms/index.html
+++ b/test/expectations/atoms/index.html
@@ -5,6 +5,7 @@
 		<title>Atoms</title>
 		<meta name="description" content="">
 		<meta name="viewport" content="width=device-width,initial-scale=1">
+		<meta name="robots" content="noindex">
 		<link href="/style-aiur.css" rel="stylesheet">
 	</head>
 	<body id="aiur">

--- a/test/expectations/atoms/strong/index.html
+++ b/test/expectations/atoms/strong/index.html
@@ -5,6 +5,7 @@
 		<title>strong</title>
 		<meta name="description" content="pretty strong component">
 		<meta name="viewport" content="width=device-width,initial-scale=1">
+		<meta name="robots" content="noindex">
 		<link href="/style-aiur.css" rel="stylesheet">
 	</head>
 	<body id="aiur">

--- a/test/expectations/index.html
+++ b/test/expectations/index.html
@@ -5,6 +5,7 @@
 		<title>My Style Guide</title>
 		<meta name="description" content="">
 		<meta name="viewport" content="width=device-width,initial-scale=1">
+		<meta name="robots" content="noindex">
 		<link href="/style-aiur.css" rel="stylesheet">
 	</head>
 	<body id="aiur">

--- a/test/fixtures/aiur.config.js
+++ b/test/fixtures/aiur.config.js
@@ -1,5 +1,9 @@
 "use strict";
 
+exports.meta = {
+	robots: "noindex"
+};
+
 exports.pages = {
 	"": "./welcome.md",
 	atoms: {


### PR DESCRIPTION
* allow to set additional meta tags via the `meta` configuration:
    * expects an object, with the keys being the `name` and the values being the `content`
* we no longer bundle the --serve and --live-serve dependencies - you will be asked to install them
* reduce faucet dependencies
* update all dependencies