### PR TITLE
Upgrade metacolon dependency

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,8 +7,8 @@ jobs:
         strategy:
             matrix:
                 node-version:
-                - 18.x
                 - 20.x
+                - 22.x
         steps:
         - uses: actions/checkout@v4
         - uses: actions/setup-node@v4

--- a/lib/page.js
+++ b/lib/page.js
@@ -1,5 +1,5 @@
 let { repr } = require("faucet-pipeline-core/lib/util");
-let colonParse = require("metacolon");
+let { colonParse } = require("metacolon");
 
 module.exports = class Page {
 	constructor(slug, sourcePath, children, { language, title, description, meta }, dataPath) {
@@ -19,19 +19,20 @@ module.exports = class Page {
 			return Promise.resolve(this);
 		}
 
-		let { headers, body } = await colonParse(this.sourcePath);
+		let { headers, body } = await colonParse(this.sourcePath, { trim: true });
 		if(this.dataPath) {
 			this.data = require(this.dataPath);
 		}
-		this.language = headers.language || this.config.language;
-		this.heading = headers.title;
-		this.title = [headers.title, this.config.title].filter(x => x).join(" | ");
-		this.description = headers.description || this.config.description;
+		let title = headers.get("title");
+		this.language = headers.get("language") || this.config.language;
+		this.heading = title;
+		this.title = [title, this.config.title].filter(x => x).join(" | ");
+		this.description = headers.get("description") || this.config.description;
 		this.meta = this.buildMeta();
-		this.status = headers.status;
-		this.version = headers.version;
-		this.tags = headers.tags;
-		this.body = body;
+		this.status = headers.get("status");
+		this.version = headers.get("version");
+		this.tags = headers.get("tags");
+		this.body = body.trim();
 		return this;
 	}
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"url": "https://github.com/faucet-pipeline/aiur/issues"
 	},
 	"engines": {
-		"node": ">= 18"
+		"node": ">= 20"
 	},
 	"dependencies": {
 		"commonmark": "^0.31.2",
@@ -31,7 +31,7 @@
 		"faucet-pipeline-sass": "^1.7.0",
 		"faucet-pipeline-static": "^2.0.0",
 		"handlebars": "^4.7.7",
-		"metacolon": "^1.1.1",
+		"metacolon": "^2.0.1",
 		"minimist": "^1.2.5",
 		"mkdirp": "^3.0.1",
 		"parse5": "^7.1.2",


### PR DESCRIPTION
I'm afraid I imposed a few [breaking changes](https://github.com/FND/metacolon/commit/873a0b492d20fdbad476e97249b57561d702b0e0) upon us, for [no good reason](https://github.com/FND/metacolon/commit/873a0b492d20fdbad476e97249b57561d702b0e0):

* requires Node v22 (for iterator helpers, mostly)
* whitespace trimming is now much more limited

The latter explains the failing tests, but I'm currently unsure how best to fix this...